### PR TITLE
fix: use supported option

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "jsxSingleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "arrowParens": "always",
   "endOfLine": "lf",
   "overrides": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/mixmaxhq/prettier-config/issues"
   },
   "homepage": "https://github.com/mixmaxhq/prettier-config#readme",
+  "peerDependency": {
+    "prettier": "^2.4.0"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^8.3.4",
     "@mixmaxhq/commitlint-jenkins": "^1.4.2",


### PR DESCRIPTION
#### Changes Made
The jsxBracketSameLine option was deprecated in 2.4.0 this allows us to support it.

#### Potential Risks
small. the option does the same thing but is renamed more clearly.

#### Test Plan
link this in repos and be sure the deprecation warning is gone.

#### Checklist
- [x] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
