### PR TITLE
feat: set `bracketSameLine` to `false`

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,10 +4,11 @@
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
+  "jsxBracketSameLine": false,
   "jsxSingleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "bracketSameLine": true,
+  "bracketSameLine": false,
   "arrowParens": "always",
   "endOfLine": "lf",
   "overrides": [


### PR DESCRIPTION
#### Changes Made

Updated config to add a break for a JSX element which has multiline props. Now the closing bracket in the opening tag should start from a new line to visually separate props and child elements.

#### Potential Risks

Can't think of anything.

#### Test Plan

- Manually set config to a new one inside `.prettierrc` for any project;
- Try adding example code like this:
```
<a
  prop1='12345'
  prop2='12345'
  prop3='12345'
  prop4='12345'
  prop5='12345'
  href='#'>
  Link
</a>
```
- Format the file and see whether it turns into:
```
<a
  prop1='12345'
  prop2='12345'
  prop3='12345'
  prop4='12345'
  prop5='12345'
  href='#'
>
  Link
</a>
```

#### Release plan

Release a new version and  bump config inside  `app` (as an example) service and test that everything works.